### PR TITLE
feat: 정보나루 API 클라이언트 및 Route Handlers 구현 (#2)

### DIFF
--- a/app/api/book-availability/route.ts
+++ b/app/api/book-availability/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchBookAvailability } from "@/lib/api/data4library";
+import type { PhysicalAvailability } from "@/types";
+
+type BookAvailabilityResponse = {
+  success: boolean;
+  data?: PhysicalAvailability[];
+  error?: string;
+};
+
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<BookAvailabilityResponse>> {
+  const { searchParams } = request.nextUrl;
+  const isbn13 = searchParams.get("isbn13")?.trim() ?? "";
+  const libCodesParam = searchParams.get("libCodes")?.trim() ?? "";
+
+  if (!isbn13) {
+    return NextResponse.json(
+      { success: false, error: "isbn13 is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!libCodesParam) {
+    return NextResponse.json(
+      { success: false, error: "libCodes is required" },
+      { status: 400 }
+    );
+  }
+
+  const libCodes = libCodesParam
+    .split(",")
+    .map((code) => code.trim())
+    .filter(Boolean);
+
+  try {
+    const results = await Promise.allSettled(
+      libCodes.map((libCode) => fetchBookAvailability(isbn13, libCode))
+    );
+
+    const data: PhysicalAvailability[] = results
+      .filter(
+        (r): r is PromiseFulfilledResult<PhysicalAvailability> =>
+          r.status === "fulfilled" && r.value !== null
+      )
+      .map((r) => r.value);
+
+    return NextResponse.json({ success: true, data });
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to fetch book availability";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/books/route.ts
+++ b/app/api/books/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { searchBooks } from "@/lib/api/data4library";
+import { searchBooks, BOOKS_PAGE_SIZE } from "@/lib/api/data4library";
 import type { Book } from "@/types";
 
 type BooksResponse = {
@@ -32,7 +32,7 @@ export async function GET(
     return NextResponse.json({
       success: true,
       data: books,
-      meta: { total, page: pageNo, limit: 10 },
+      meta: { total, page: pageNo, limit: BOOKS_PAGE_SIZE },
     });
   } catch (error: unknown) {
     const message =

--- a/app/api/books/route.ts
+++ b/app/api/books/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { searchBooks } from "@/lib/api/data4library";
+import type { Book } from "@/types";
+
+type BooksResponse = {
+  success: boolean;
+  data?: Book[];
+  error?: string;
+  meta?: {
+    total: number;
+    page: number;
+    limit: number;
+  };
+};
+
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<BooksResponse>> {
+  const { searchParams } = request.nextUrl;
+  const keyword = searchParams.get("keyword")?.trim() ?? "";
+  const pageNo = Math.max(1, Number(searchParams.get("pageNo") ?? "1"));
+
+  if (!keyword) {
+    return NextResponse.json(
+      { success: false, error: "keyword is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { books, total } = await searchBooks(keyword, pageNo);
+    return NextResponse.json({
+      success: true,
+      data: books,
+      meta: { total, page: pageNo, limit: 10 },
+    });
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "Failed to search books";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/libraries/route.ts
+++ b/app/api/libraries/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { fetchSeoulLibraries } from "@/lib/api/data4library";
+import type { Library } from "@/types";
+
+type LibrariesResponse = {
+  success: boolean;
+  data?: Library[];
+  error?: string;
+};
+
+export const revalidate = 86400;
+
+export async function GET(): Promise<NextResponse<LibrariesResponse>> {
+  try {
+    const libraries = await fetchSeoulLibraries();
+    return NextResponse.json({ success: true, data: libraries });
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "Failed to fetch libraries";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/api/data4library.ts
+++ b/lib/api/data4library.ts
@@ -1,0 +1,142 @@
+import type { Book, Library, PhysicalAvailability } from "@/types";
+
+const BASE_URL = "https://data4library.kr/api";
+const SEOUL_REGION_CODE = "11";
+
+function getApiKey(): string {
+  const key = process.env.DATA4LIBRARY_API_KEY;
+  if (!key) {
+    throw new Error("DATA4LIBRARY_API_KEY is not configured");
+  }
+  return key;
+}
+
+function buildUrl(path: string, params: Record<string, string>): string {
+  const url = new URL(`${BASE_URL}${path}`);
+  url.searchParams.set("authKey", getApiKey());
+  url.searchParams.set("format", "json");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+type Data4LibraryLibItem = {
+  libCode: string;
+  libName: string;
+  address: string;
+  tel: string;
+  homepage: string;
+  closed: string;
+  operatingTime: string;
+};
+
+type Data4LibraryBookItem = {
+  title: string;
+  author: string;
+  publisher: string;
+  publicationYear: string;
+  isbn13: string;
+  bookImageURL: string;
+  description: string;
+};
+
+type Data4LibraryAvailabilityResult = {
+  hasBook: "Y" | "N";
+  loanAvailable: "Y" | "N";
+};
+
+export async function fetchSeoulLibraries(): Promise<Library[]> {
+  const url = buildUrl("/libSrch", { region: SEOUL_REGION_CODE });
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Libraries API error: ${response.status}`);
+  }
+
+  const json = (await response.json()) as {
+    response?: {
+      libs?: Array<{ lib: Data4LibraryLibItem }>;
+    };
+  };
+
+  const items = json.response?.libs ?? [];
+  return items.map(({ lib }) => ({
+    libCode: lib.libCode,
+    libName: lib.libName,
+    address: lib.address,
+    tel: lib.tel,
+    homepage: lib.homepage,
+    closed: lib.closed,
+    operatingTime: lib.operatingTime,
+  }));
+}
+
+export async function searchBooks(
+  keyword: string,
+  pageNo: number
+): Promise<{ books: Book[]; total: number }> {
+  const url = buildUrl("/srchBooks", {
+    keyword,
+    pageNo: String(pageNo),
+    pageSize: "10",
+  });
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Books API error: ${response.status}`);
+  }
+
+  const json = (await response.json()) as {
+    response?: {
+      numFound?: number;
+      docs?: Array<{ doc: Data4LibraryBookItem }>;
+    };
+  };
+
+  const items = json.response?.docs ?? [];
+  const total = json.response?.numFound ?? 0;
+
+  return {
+    books: items.map(({ doc }) => ({
+      title: doc.title,
+      author: doc.author,
+      publisher: doc.publisher,
+      publicationYear: doc.publicationYear,
+      isbn13: doc.isbn13,
+      bookImageURL: doc.bookImageURL,
+      description: doc.description,
+    })),
+    total,
+  };
+}
+
+export async function fetchBookAvailability(
+  isbn13: string,
+  libCode: string
+): Promise<PhysicalAvailability | null> {
+  const url = buildUrl("/bookExist", { isbn13, libCode });
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const json = (await response.json()) as {
+    response?: {
+      result?: Data4LibraryAvailabilityResult;
+      libCode?: string;
+      libName?: string;
+    };
+  };
+
+  const result = json.response?.result;
+  if (!result) return null;
+
+  return {
+    libCode,
+    libName: json.response?.libName ?? "",
+    hasBook: result.hasBook,
+    loanAvailable: result.loanAvailable,
+  };
+}

--- a/lib/api/data4library.ts
+++ b/lib/api/data4library.ts
@@ -1,7 +1,9 @@
+import "server-only";
 import type { Book, Library, PhysicalAvailability } from "@/types";
 
 const BASE_URL = "https://data4library.kr/api";
 const SEOUL_REGION_CODE = "11";
+export const BOOKS_PAGE_SIZE = 10;
 
 function getApiKey(): string {
   const key = process.env.DATA4LIBRARY_API_KEY;
@@ -79,7 +81,7 @@ export async function searchBooks(
   const url = buildUrl("/srchBooks", {
     keyword,
     pageNo: String(pageNo),
-    pageSize: "10",
+    pageSize: String(BOOKS_PAGE_SIZE),
   });
   const response = await fetch(url);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "^16.2.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "server-only": "^0.0.1",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -1151,6 +1152,111 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -6459,6 +6565,11 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -7896,111 +8007,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "^16.2.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "server-only": "^0.0.1",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"


### PR DESCRIPTION
## Summary

- `lib/api/data4library.ts`: 정보나루 API 클라이언트 (서버 전용)
- `app/api/libraries/route.ts`: 서울시 도서관 목록 (revalidate: 86400)
- `app/api/books/route.ts`: 도서 키워드 검색 (keyword, pageNo)
- `app/api/book-availability/route.ts`: 실물 소장/대출 여부 (isbn13, libCodes 병렬 처리)

## 구현 포인트

- API Key는 `DATA4LIBRARY_API_KEY` 환경변수를 통해 서버에서만 사용
- `/api/book-availability`는 `Promise.allSettled`로 여러 도서관 병렬 호출, 실패한 도서관은 결과에서 제외
- `/api/libraries`는 하루 단위 revalidate로 ISR 처리

## Test plan

- [ ] `GET /api/libraries` — 서울시 도서관 목록 반환 확인
- [ ] `GET /api/books?keyword=파친코&pageNo=1` — 도서 검색 결과 + meta 확인
- [ ] `GET /api/book-availability?isbn13=...&libCodes=111001,111002` — 병렬 호출 및 응답 확인
- [ ] `keyword` 없이 `/api/books` 호출 시 400 에러 반환 확인
- [ ] `DATA4LIBRARY_API_KEY` 미설정 시 500 에러 반환 확인

Closes #2