### PR TITLE
[Scraper] 전자도서관 소장 여부 스크래퍼 + Route Handler

### DIFF
--- a/app/api/ebook-availability/route.ts
+++ b/app/api/ebook-availability/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { scrapeEbookAvailabilityBatch } from "@/lib/api/ebook-scraper";
+import type { EbookScrapeResult } from "@/lib/api/ebook-scraper";
+
+type EbookAvailabilityResponse = {
+  success: boolean;
+  data?: EbookScrapeResult[];
+  error?: string;
+};
+
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<EbookAvailabilityResponse>> {
+  const searchParams = new URL(request.url).searchParams;
+  const keyword = searchParams.get("keyword")?.trim() ?? "";
+  const libCodesParam = searchParams.get("libCodes")?.trim() ?? "";
+
+  if (!keyword) {
+    return NextResponse.json(
+      { success: false, error: "keyword is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!libCodesParam) {
+    return NextResponse.json(
+      { success: false, error: "libCodes is required" },
+      { status: 400 }
+    );
+  }
+
+  const libCodes = libCodesParam
+    .split(",")
+    .map((code) => code.trim())
+    .filter(Boolean);
+
+  const data = await scrapeEbookAvailabilityBatch(keyword, libCodes);
+
+  return NextResponse.json({ success: true, data });
+}

--- a/lib/api/ebook-scraper.ts
+++ b/lib/api/ebook-scraper.ts
@@ -1,0 +1,66 @@
+import "server-only";
+import { EBOOK_LIBRARY_CONFIGS } from "@/lib/constants/ebook-library-config";
+
+const TIMEOUT_MS = 5000;
+
+export type EbookScrapeResult =
+  | { libCode: string; libName: string; ebookAvailable: "Y" | "N" }
+  | { libCode: string; error: string };
+
+export async function scrapeEbookAvailability(
+  keyword: string,
+  libCode: string
+): Promise<EbookScrapeResult> {
+  const config = EBOOK_LIBRARY_CONFIGS[libCode];
+
+  if (!config) {
+    return { libCode, error: "전자도서관 미운영" };
+  }
+
+  try {
+    const url = config.searchUrl(keyword);
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; library-checker/1.0)" },
+    });
+
+    if (!response.ok) {
+      return { libCode, error: "조회 실패" };
+    }
+
+    const html = await response.text();
+    const isEmpty = config.emptyTexts.some((text) => html.includes(text));
+
+    if (isEmpty) {
+      return { libCode, libName: config.libName, ebookAvailable: "N" };
+    }
+
+    const isAvailable = config.availableTexts.some((text) =>
+      html.includes(text)
+    );
+
+    return {
+      libCode,
+      libName: config.libName,
+      ebookAvailable: isAvailable ? "Y" : "N",
+    };
+  } catch {
+    return { libCode, error: "조회 실패" };
+  }
+}
+
+export async function scrapeEbookAvailabilityBatch(
+  keyword: string,
+  libCodes: string[]
+): Promise<EbookScrapeResult[]> {
+  const results = await Promise.allSettled(
+    libCodes.map((libCode) => scrapeEbookAvailability(keyword, libCode))
+  );
+
+  return results.map((result, index) => {
+    if (result.status === "fulfilled") {
+      return result.value;
+    }
+    return { libCode: libCodes[index], error: "조회 실패" };
+  });
+}

--- a/lib/constants/ebook-library-config.ts
+++ b/lib/constants/ebook-library-config.ts
@@ -1,0 +1,13 @@
+export type EbookLibraryConfig = {
+  libName: string;
+  searchUrl: (keyword: string) => string;
+  emptyTexts: string[];
+  availableTexts: string[];
+};
+
+// libCode → 전자도서관 스크래핑 설정
+// libCode: 정보나루 API의 도서관 코드
+//
+// 각 도서관의 전자도서관 URL은 수동 검증이 필요하므로 현재 비어 있음.
+// 추후 자동 발견 기능(이슈 #4)에서 채워질 예정.
+export const EBOOK_LIBRARY_CONFIGS: Record<string, EbookLibraryConfig> = {};


### PR DESCRIPTION
## Summary

- `lib/constants/ebook-library-config.ts` — 도서관별 스크래핑 설정 타입 정의 (EbookLibraryConfig)
- `lib/api/ebook-scraper.ts` — fetch + 텍스트 검색 기반 스크래퍼 (cheerio 미사용)
- `app/api/ebook-availability/route.ts` — GET `/api/ebook-availability?keyword=&libCodes=`

## 설계 원칙

- cheerio 없이 `html.includes()` 단순 텍스트 검색
- `AbortSignal.timeout(5000)` 5초 타임아웃
- 설정 없는 도서관 → `"전자도서관 미운영"`
- 스크래핑 실패 → `"조회 실패"` graceful degradation
- `Promise.allSettled` 병렬 스크래핑

## 참고

전자도서관 URL 자동 발견 기능(각 도서관 homepage에서 전자도서관 링크 추출)은 테스트가 필요하여 별도 이슈 #9로 분리.
현재 `EBOOK_LIBRARY_CONFIGS`는 빈 객체로, 이슈 #9 완료 후 채워질 예정.

## Test plan

- [ ] `GET /api/ebook-availability?keyword=해리포터&libCodes=111021` → `{ error: "전자도서관 미운영" }` 확인
- [ ] 존재하지 않는 libCode → graceful degradation 확인
- [ ] TypeScript 빌드 에러 없음 확인

Closes #3