### PR TITLE
[UI] 홈 페이지 (도서관 선택 + 검색 폼)

### DIFF
--- a/app/api/ebook-availability/route.ts
+++ b/app/api/ebook-availability/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { scrapeEbookAvailabilityBatch } from "@/lib/api/ebook-scraper";
+import type { EbookScrapeResult } from "@/lib/api/ebook-scraper";
+
+type EbookAvailabilityResponse = {
+  success: boolean;
+  data?: EbookScrapeResult[];
+  error?: string;
+};
+
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<EbookAvailabilityResponse>> {
+  const searchParams = new URL(request.url).searchParams;
+  const keyword = searchParams.get("keyword")?.trim() ?? "";
+  const libCodesParam = searchParams.get("libCodes")?.trim() ?? "";
+
+  if (!keyword) {
+    return NextResponse.json(
+      { success: false, error: "keyword is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!libCodesParam) {
+    return NextResponse.json(
+      { success: false, error: "libCodes is required" },
+      { status: 400 }
+    );
+  }
+
+  const libCodes = libCodesParam
+    .split(",")
+    .map((code) => code.trim())
+    .filter(Boolean);
+
+  const data = await scrapeEbookAvailabilityBatch(keyword, libCodes);
+
+  return NextResponse.json({ success: true, data });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,10 +3,10 @@ import "./globals.css";
 import { Geist } from "next/font/google";
 import { cn } from "@/lib/utils";
 
-const geist = Geist({subsets:['latin'],variable:'--font-sans'});
+const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
-  title: "도서관 책 찾기",
+  title: "도서관 책 한 번에 찾기",
   description: "서울 공공도서관 실물/전자책 통합 검색 서비스",
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,37 @@
-export default function HomePage() {
+import { Suspense } from "react";
+import { HomePageClient } from "@/components/HomePageClient";
+import { fetchSeoulLibraries } from "@/lib/api/data4library";
+import type { Library } from "@/types";
+
+async function fetchLibraries(): Promise<Library[]> {
+  try {
+    return await fetchSeoulLibraries();
+  } catch {
+    return [];
+  }
+}
+
+export default async function HomePage() {
+  const libraries = await fetchLibraries();
+
   return (
-    <main className="min-h-screen p-8">
-      <h1 className="text-2xl font-bold">도서관 책 찾기</h1>
+    <main className="mx-auto min-h-screen max-w-2xl px-4 py-10">
+      <header className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight">
+          도서관 책 한 번에 찾기
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          서울 소재 도서관에서 빌리고 싶은 책을 검색해보세요.
+        </p>
+      </header>
+
+      <Suspense
+        fallback={
+          <div className="text-sm text-muted-foreground">로딩 중...</div>
+        }
+      >
+        <HomePageClient allLibraries={libraries} />
+      </Suspense>
     </main>
   );
 }

--- a/components/HomePageClient.tsx
+++ b/components/HomePageClient.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { LibrarySelector } from "@/components/library/LibrarySelector";
+import { SelectedLibraryBadges } from "@/components/library/SelectedLibraryBadges";
+import { SearchForm } from "@/components/search/SearchForm";
+import { parseLibCodes, serializeLibCodes } from "@/lib/utils/url-params";
+import type { Library } from "@/types";
+
+interface HomePageClientProps {
+  allLibraries: Library[];
+}
+
+export function HomePageClient({ allLibraries }: HomePageClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [selectedLibCodes, setSelectedLibCodes] = useState<string[]>(() =>
+    parseLibCodes(searchParams),
+  );
+
+  function handleSelectionChange(libCodes: string[]) {
+    setSelectedLibCodes(libCodes);
+
+    const params = new URLSearchParams(searchParams.toString());
+    if (libCodes.length > 0) {
+      params.set("libs", serializeLibCodes(libCodes));
+    } else {
+      params.delete("libs");
+    }
+    router.replace(`/?${params.toString()}`, { scroll: false });
+  }
+
+  function handleRemove(libCode: string) {
+    handleSelectionChange(selectedLibCodes.filter((code) => code !== libCode));
+  }
+
+  const selectedLibraries = selectedLibCodes
+    .map((code) => allLibraries.find((lib) => lib.libCode === code))
+    .filter((lib): lib is Library => lib !== undefined)
+    .map((lib) => ({ libCode: lib.libCode, libName: lib.libName }));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section aria-label="도서관 검색">
+        <h2 className="mb-2 text-sm font-medium text-foreground">
+          도서관 검색
+        </h2>
+        <LibrarySelector
+          allLibraries={allLibraries}
+          selectedLibCodes={selectedLibCodes}
+          onSelectionChange={handleSelectionChange}
+        />
+        {selectedLibraries.length > 0 && (
+          <div className="mt-3">
+            <SelectedLibraryBadges
+              selectedLibraries={selectedLibraries}
+              onRemove={handleRemove}
+            />
+          </div>
+        )}
+      </section>
+
+      <section aria-label="책 검색">
+        <h2 className="mb-2 text-sm font-medium text-foreground">책 검색</h2>
+        <SearchForm selectedLibCodes={selectedLibCodes} />
+      </section>
+    </div>
+  );
+}

--- a/components/library/LibrarySelector.tsx
+++ b/components/library/LibrarySelector.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import type { Library } from "@/types";
+import { cn } from "@/lib/utils";
+
+const MAX_SELECTION = 7;
+
+interface LibrarySelectorProps {
+  allLibraries: Library[];
+  selectedLibCodes: string[];
+  onSelectionChange: (libCodes: string[]) => void;
+}
+
+export function LibrarySelector({
+  allLibraries,
+  selectedLibCodes,
+  onSelectionChange,
+}: LibrarySelectorProps) {
+  const [query, setQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const isMaxReached = selectedLibCodes.length >= MAX_SELECTION;
+
+  const filtered =
+    query.trim().length > 0
+      ? allLibraries.filter((lib) =>
+          lib.libName.toLowerCase().includes(query.trim().toLowerCase())
+        )
+      : [];
+
+  function handleSelect(lib: Library) {
+    if (selectedLibCodes.includes(lib.libCode)) return;
+    if (isMaxReached) return;
+    onSelectionChange([...selectedLibCodes, lib.libCode]);
+    setQuery("");
+    setIsOpen(false);
+  }
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setIsOpen(true);
+        }}
+        onFocus={() => query.trim().length > 0 && setIsOpen(true)}
+        placeholder={
+          isMaxReached
+            ? `최대 ${MAX_SELECTION}개 선택됨`
+            : "도서관 이름을 입력하세요 (예: 강남, 마포)"
+        }
+        disabled={isMaxReached}
+        className={cn(
+          "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          isMaxReached && "cursor-not-allowed opacity-50"
+        )}
+      />
+
+      {isOpen && filtered.length > 0 && (
+        <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-border bg-background shadow-md">
+          {filtered.map((lib) => {
+            const isSelected = selectedLibCodes.includes(lib.libCode);
+            return (
+              <li key={lib.libCode}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(lib)}
+                  disabled={isSelected}
+                  className={cn(
+                    "w-full px-3 py-2 text-left text-sm transition-colors",
+                    isSelected
+                      ? "cursor-default text-muted-foreground"
+                      : "hover:bg-muted"
+                  )}
+                >
+                  <span>{lib.libName}</span>
+                  {isSelected && (
+                    <span className="ml-2 text-xs text-muted-foreground">선택됨</span>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {isOpen && query.trim().length > 0 && filtered.length === 0 && (
+        <div className="absolute z-10 mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-muted-foreground shadow-md">
+          검색 결과가 없습니다
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/library/SelectedLibraryBadges.tsx
+++ b/components/library/SelectedLibraryBadges.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+interface SelectedLibrary {
+  libCode: string;
+  libName: string;
+}
+
+interface SelectedLibraryBadgesProps {
+  selectedLibraries: SelectedLibrary[];
+  onRemove: (libCode: string) => void;
+}
+
+export function SelectedLibraryBadges({
+  selectedLibraries,
+  onRemove,
+}: SelectedLibraryBadgesProps) {
+  if (selectedLibraries.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        도서관을 선택해주세요
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {selectedLibraries.map((lib) => (
+        <li key={lib.libCode}>
+          <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-sm font-medium">
+            {lib.libName}
+            <button
+              type="button"
+              onClick={() => onRemove(lib.libCode)}
+              aria-label={`${lib.libName} 선택 해제`}
+              className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <svg
+                className="size-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/search/SearchForm.tsx
+++ b/components/search/SearchForm.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { serializeLibCodes } from "@/lib/utils/url-params";
+
+interface SearchFormProps {
+  selectedLibCodes: string[];
+}
+
+export function SearchForm({ selectedLibCodes }: SearchFormProps) {
+  const router = useRouter();
+  const [keyword, setKeyword] = useState("");
+
+  const isDisabled =
+    selectedLibCodes.length === 0 || keyword.trim().length === 0;
+
+  function handleSubmit(e: React.ChangeEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (isDisabled) return;
+
+    const params = new URLSearchParams({
+      q: keyword.trim(),
+      libs: serializeLibCodes(selectedLibCodes),
+    });
+    router.push(`/search?${params.toString()}`);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="책 제목 또는 저자를 입력하세요"
+          className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+        <Button type="submit" disabled={isDisabled}>
+          검색
+        </Button>
+      </div>
+      {selectedLibCodes.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          검색하려면 도서관을 먼저 선택해주세요
+        </p>
+      )}
+    </form>
+  );
+}

--- a/lib/api/ebook-scraper.ts
+++ b/lib/api/ebook-scraper.ts
@@ -1,0 +1,66 @@
+import "server-only";
+import { EBOOK_LIBRARY_CONFIGS } from "@/lib/constants/ebook-library-config";
+
+const TIMEOUT_MS = 5000;
+
+export type EbookScrapeResult =
+  | { libCode: string; libName: string; ebookAvailable: "Y" | "N" }
+  | { libCode: string; error: string };
+
+export async function scrapeEbookAvailability(
+  keyword: string,
+  libCode: string
+): Promise<EbookScrapeResult> {
+  const config = EBOOK_LIBRARY_CONFIGS[libCode];
+
+  if (!config) {
+    return { libCode, error: "전자도서관 미운영" };
+  }
+
+  try {
+    const url = config.searchUrl(keyword);
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; library-checker/1.0)" },
+    });
+
+    if (!response.ok) {
+      return { libCode, error: "조회 실패" };
+    }
+
+    const html = await response.text();
+    const isEmpty = config.emptyTexts.some((text) => html.includes(text));
+
+    if (isEmpty) {
+      return { libCode, libName: config.libName, ebookAvailable: "N" };
+    }
+
+    const isAvailable = config.availableTexts.some((text) =>
+      html.includes(text)
+    );
+
+    return {
+      libCode,
+      libName: config.libName,
+      ebookAvailable: isAvailable ? "Y" : "N",
+    };
+  } catch {
+    return { libCode, error: "조회 실패" };
+  }
+}
+
+export async function scrapeEbookAvailabilityBatch(
+  keyword: string,
+  libCodes: string[]
+): Promise<EbookScrapeResult[]> {
+  const results = await Promise.allSettled(
+    libCodes.map((libCode) => scrapeEbookAvailability(keyword, libCode))
+  );
+
+  return results.map((result, index) => {
+    if (result.status === "fulfilled") {
+      return result.value;
+    }
+    return { libCode: libCodes[index], error: "조회 실패" };
+  });
+}

--- a/lib/constants/ebook-library-config.ts
+++ b/lib/constants/ebook-library-config.ts
@@ -1,0 +1,13 @@
+export type EbookLibraryConfig = {
+  libName: string;
+  searchUrl: (keyword: string) => string;
+  emptyTexts: string[];
+  availableTexts: string[];
+};
+
+// libCode → 전자도서관 스크래핑 설정
+// libCode: 정보나루 API의 도서관 코드
+//
+// 각 도서관의 전자도서관 URL은 수동 검증이 필요하므로 현재 비어 있음.
+// 추후 자동 발견 기능(이슈 #4)에서 채워질 예정.
+export const EBOOK_LIBRARY_CONFIGS: Record<string, EbookLibraryConfig> = {};

--- a/lib/utils/url-params.ts
+++ b/lib/utils/url-params.ts
@@ -1,0 +1,12 @@
+export function parseLibCodes(searchParams: URLSearchParams): string[] {
+  const libs = searchParams.get("libs");
+  if (!libs) return [];
+  return libs
+    .split(",")
+    .map((code) => code.trim())
+    .filter((code) => code.length > 0);
+}
+
+export function serializeLibCodes(libCodes: string[]): string {
+  return libCodes.join(",");
+}


### PR DESCRIPTION
## Summary

- 도서관 이름 검색으로 선택하는 `LibrarySelector` 구현 (타이핑 → 드롭다운 → 클릭 선택, 최대 7개)
- 선택된 도서관 배지 표시 및 X 버튼으로 개별 제거 (`SelectedLibraryBadges`)
- 검색어 + 도서관 미선택 시 버튼 disabled 처리 (`SearchForm`)
- URL 파라미터 동기화: `?libs=코드1,코드2` (선택 변경 시 즉시 반영)
- Server Component에서 `fetchSeoulLibraries()` 직접 호출 (HTTP 우회)
- URL 파라미터 파싱/직렬화 유틸 추가 (`lib/utils/url-params.ts`)

## 유저 흐름

1. 도서관 선택 입력창에 이름 입력 (예: "강남", "마포")
2. 드롭다운에서 도서관 클릭 → 배지로 추가 (최대 7개)
3. 책 제목/저자 입력 후 검색 → `/search?q=파친코&libs=111001,111002` 이동

## Test plan

- [ ] 도서관 이름 입력 시 드롭다운 필터링 확인
- [ ] 7개 선택 후 입력창 disabled 확인
- [ ] 배지 X 클릭 시 선택 해제 + URL 업데이트 확인
- [ ] 검색 submit → `/search?q=...&libs=...` URL 이동 확인
- [ ] `npm run typecheck` 통과 확인

Closes #4