### PR TITLE
feat: Tier 1 물리적 소장 여부 조회 (#12 PR1)

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -4,6 +4,8 @@ import {
   fetchSeoulLibraries,
   BOOKS_PAGE_SIZE,
 } from "@/lib/api/data4library";
+import { getPhysicalOwnership } from "@/lib/services/book-existence";
+import type { PhysicalOwnership } from "@/lib/services/book-existence";
 import { SearchHeader } from "@/components/search/SearchHeader";
 import { BookCard } from "@/components/search/BookCard";
 import { EmptyState } from "@/components/search/EmptyState";
@@ -43,6 +45,20 @@ export default async function SearchPage(props: {
     selectedLibCodes.includes(lib.libCode),
   );
 
+  const ownershipResults = await Promise.allSettled(
+    books.map((book) => getPhysicalOwnership(book.isbn13)),
+  );
+
+  const ownershipByIsbn = new Map<string, PhysicalOwnership | null>();
+  books.forEach((book, index) => {
+    const settled = ownershipResults[index];
+    if (settled.status === "fulfilled" && settled.value.success) {
+      ownershipByIsbn.set(book.isbn13, settled.value.data);
+    } else {
+      ownershipByIsbn.set(book.isbn13, null);
+    }
+  });
+
   return (
     <main className="mx-auto min-h-screen max-w-2xl px-4 py-10">
       <SearchHeader
@@ -61,6 +77,7 @@ export default async function SearchPage(props: {
                 key={book.isbn13}
                 book={book}
                 libraries={selectedLibraries}
+                ownership={ownershipByIsbn.get(book.isbn13) ?? null}
               />
             ))}
           </div>

--- a/components/search/BookCard.tsx
+++ b/components/search/BookCard.tsx
@@ -1,16 +1,18 @@
 import { Suspense } from "react";
 import Image from "next/image";
-import { PhysicalAvailabilityCell } from "@/components/search/PhysicalAvailabilityCell";
+import { PhysicalOwnershipBadge } from "@/components/search/PhysicalOwnershipBadge";
 import { EbookAvailabilityCell } from "@/components/search/EbookAvailabilityCell";
 import { AvailabilitySkeleton } from "@/components/search/AvailabilitySkeleton";
+import type { PhysicalOwnership } from "@/lib/services/book-existence";
 import type { Book, Library } from "@/types";
 
 interface BookCardProps {
   book: Book;
   libraries: Library[];
+  ownership: PhysicalOwnership | null;
 }
 
-export function BookCard({ book, libraries }: BookCardProps) {
+export function BookCard({ book, libraries, ownership }: BookCardProps) {
   return (
     <article className="rounded-lg border border-border p-4">
       <div className="flex gap-4">
@@ -62,12 +64,10 @@ export function BookCard({ book, libraries }: BookCardProps) {
               </td>
               {libraries.map((lib) => (
                 <td key={lib.libCode} className="px-3 py-2">
-                  <Suspense fallback={<AvailabilitySkeleton />}>
-                    <PhysicalAvailabilityCell
-                      isbn13={book.isbn13}
-                      libCode={lib.libCode}
-                    />
-                  </Suspense>
+                  <PhysicalOwnershipBadge
+                    ownership={ownership}
+                    libCode={lib.libCode}
+                  />
                 </td>
               ))}
             </tr>

--- a/components/search/PhysicalOwnershipBadge.tsx
+++ b/components/search/PhysicalOwnershipBadge.tsx
@@ -1,0 +1,22 @@
+import type { PhysicalOwnership } from "@/lib/services/book-existence";
+import { isOwnedBy } from "@/lib/services/book-existence";
+
+interface PhysicalOwnershipBadgeProps {
+  ownership: PhysicalOwnership | null;
+  libCode: string;
+}
+
+export function PhysicalOwnershipBadge({
+  ownership,
+  libCode,
+}: PhysicalOwnershipBadgeProps) {
+  if (ownership === null) {
+    return <span className="text-sm text-muted-foreground">조회 실패</span>;
+  }
+
+  if (!isOwnedBy(ownership, libCode)) {
+    return <span className="text-sm text-muted-foreground">미소장</span>;
+  }
+
+  return <span className="text-sm font-medium text-green-600">소장</span>;
+}

--- a/lib/api/data4library.ts
+++ b/lib/api/data4library.ts
@@ -4,6 +4,11 @@ import type { Book, Library, PhysicalAvailability } from "@/types";
 const BASE_URL = "https://data4library.kr/api";
 const SEOUL_REGION_CODE = "11";
 export const BOOKS_PAGE_SIZE = 10;
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export type Result<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
 
 function getApiKey(): string {
   const key = process.env.DATA4LIBRARY_API_KEY;
@@ -154,6 +159,47 @@ export async function searchBooks(
   const pageBooks = filtered.slice(start, start + BOOKS_PAGE_SIZE);
 
   return { books: pageBooks, total: filtered.length };
+}
+
+type Data4LibraryLibByBookResponse = {
+  response?: {
+    numFound?: number;
+    libs?: Array<{ lib: { libCode: string; libName?: string } }>;
+  };
+};
+
+export async function fetchLibrariesByBook(
+  isbn13: string,
+  region: string = SEOUL_REGION_CODE,
+): Promise<Result<{ libCodes: string[] }>> {
+  try {
+    const url = buildUrl("/libSrchByBook", {
+      isbn: isbn13,
+      region,
+    });
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `libSrchByBook API error: ${response.status}`,
+      };
+    }
+
+    const json = (await response.json()) as Data4LibraryLibByBookResponse;
+    const items = json.response?.libs ?? [];
+    const libCodes = items
+      .map(({ lib }) => lib.libCode)
+      .filter((code): code is string => Boolean(code));
+
+    return { success: true, data: { libCodes } };
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "libSrchByBook request failed";
+    return { success: false, error: message };
+  }
 }
 
 export async function fetchBookAvailability(

--- a/lib/services/book-existence.ts
+++ b/lib/services/book-existence.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import {
+  fetchLibrariesByBook,
+  type Result,
+} from "@/lib/api/data4library";
+
+export type PhysicalOwnership = {
+  owningLibCodes: Set<string>;
+};
+
+export async function getPhysicalOwnership(
+  isbn13: string,
+): Promise<Result<PhysicalOwnership>> {
+  const result = await fetchLibrariesByBook(isbn13);
+
+  if (!result.success) {
+    return result;
+  }
+
+  return {
+    success: true,
+    data: { owningLibCodes: new Set(result.data.libCodes) },
+  };
+}
+
+export function isOwnedBy(
+  ownership: PhysicalOwnership,
+  libCode: string,
+): boolean {
+  return ownership.owningLibCodes.has(libCode);
+}


### PR DESCRIPTION
## Summary
이슈 #12의 3-Tier Progressive Discovery 모델 전환 중 **Tier 1** 구현.

- `libSrchByBook` API로 책당 1회 호출하여 서울 전체 도서관 중 소장 도서관 목록 조회
- 기존 도서관별 반복 호출(N×M)을 책당 1회(N)로 축소

## 변경 사항
- `lib/api/data4library.ts`: `fetchLibrariesByBook(isbn13, region)` 추가 (Result 패턴 + `AbortSignal.timeout(5000)`)
- `lib/services/book-existence.ts` (신규): Tier 1 도메인 로직
- `components/search/PhysicalOwnershipBadge.tsx` (신규): 소장/미소장/조회 실패 배지
- `app/search/page.tsx`: `Promise.allSettled`로 책당 1회 호출 후 `BookCard`로 전달
- `components/search/BookCard.tsx`: `PhysicalAvailabilityCell` → `PhysicalOwnershipBadge` 교체

## 후속 작업
- PR2: Tier 2 전자책 존재 여부 (24h 캐시)
- PR3: Tier 3 실시간 대출 가능 여부 (on-demand 버튼)
- PR4: Cleanup — `PhysicalAvailabilityCell`, `fetchBookAvailability` 등 미사용 코드 제거

## 테스트
- 프로젝트에 테스트 프레임워크(vitest/jest)가 아직 구성되어 있지 않아 이번 PR에서는 유닛 테스트를 포함하지 않음. 테스트 하네스 도입은 별도 이슈로 분리 권장.
- `npx tsc --noEmit` 통과

## Self-review (CLAUDE.md 체크리스트)
- [x] 외부 API 호출 타임아웃(`AbortSignal.timeout(5000)`)
- [x] Result 패턴 (`{ success, data | error }`)
- [x] 컴포넌트에 비즈니스 로직 없음 (`isOwnedBy`는 `lib/services/`)
- [x] Server Component 유지, `"use client"` 추가 없음
- [x] Props는 `interface`로 정의
- [x] `@/` 절대 경로 사용
- [x] 파일 400줄 이하

## Test plan
- [ ] `/search?q=...&libs=...` 진입 시 소장/미소장 배지가 선택한 도서관별로 정확히 표시되는지 확인
- [ ] `libSrchByBook` 네트워크 호출이 검색 결과 책 수만큼만 발생하는지 DevTools로 확인
- [ ] API 일시 장애/타임아웃 시 "조회 실패" 배지가 노출되는지 확인