### PR TITLE
feat: Tier 2 전자책 존재 여부 (24h 캐시) (#12 PR2)

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -4,12 +4,50 @@ import {
   fetchSeoulLibraries,
   BOOKS_PAGE_SIZE,
 } from "@/lib/api/data4library";
-import { getPhysicalOwnership } from "@/lib/services/book-existence";
-import type { PhysicalOwnership } from "@/lib/services/book-existence";
+import {
+  getPhysicalOwnership,
+  getEbookExistence,
+} from "@/lib/services/book-existence";
+import type {
+  PhysicalOwnership,
+  EbookExistence,
+} from "@/lib/services/book-existence";
 import { SearchHeader } from "@/components/search/SearchHeader";
 import { BookCard } from "@/components/search/BookCard";
 import { EmptyState } from "@/components/search/EmptyState";
 import { SearchPagination } from "@/components/search/SearchPagination";
+import type { Book, Library } from "@/types";
+
+type PerBookTier = {
+  ownership: PhysicalOwnership | null;
+  ebook: EbookExistence | null;
+};
+
+/**
+ * 책 1권에 대해 Tier 1(실물 소장)과 Tier 2(전자책 존재)를 병렬로 조회한다.
+ * 하나가 실패해도 다른 Tier는 영향받지 않는다.
+ */
+async function fetchTiersForBook(
+  book: Book,
+  libraries: ReadonlyArray<Library>,
+): Promise<PerBookTier> {
+  const [ownershipSettled, ebookSettled] = await Promise.allSettled([
+    getPhysicalOwnership(book.isbn13),
+    getEbookExistence(book.title, libraries),
+  ]);
+
+  const ownership =
+    ownershipSettled.status === "fulfilled" && ownershipSettled.value.success
+      ? ownershipSettled.value.data
+      : null;
+
+  const ebook =
+    ebookSettled.status === "fulfilled" && ebookSettled.value.success
+      ? ebookSettled.value.data
+      : null;
+
+  return { ownership, ebook };
+}
 
 export default async function SearchPage(props: {
   searchParams: Promise<{ q?: string; libs?: string; page?: string }>;
@@ -45,19 +83,10 @@ export default async function SearchPage(props: {
     selectedLibCodes.includes(lib.libCode),
   );
 
-  const ownershipResults = await Promise.allSettled(
-    books.map((book) => getPhysicalOwnership(book.isbn13)),
+  // 책별로 Tier 1 + Tier 2 병렬 조회. 책 간에도 Promise.all로 병렬화.
+  const tiers = await Promise.all(
+    books.map((book) => fetchTiersForBook(book, selectedLibraries)),
   );
-
-  const ownershipByIsbn = new Map<string, PhysicalOwnership | null>();
-  books.forEach((book, index) => {
-    const settled = ownershipResults[index];
-    if (settled.status === "fulfilled" && settled.value.success) {
-      ownershipByIsbn.set(book.isbn13, settled.value.data);
-    } else {
-      ownershipByIsbn.set(book.isbn13, null);
-    }
-  });
 
   return (
     <main className="mx-auto min-h-screen max-w-2xl px-4 py-10">
@@ -72,12 +101,13 @@ export default async function SearchPage(props: {
       ) : (
         <>
           <div className="flex flex-col gap-4">
-            {books.map((book) => (
+            {books.map((book, index) => (
               <BookCard
                 key={book.isbn13}
                 book={book}
                 libraries={selectedLibraries}
-                ownership={ownershipByIsbn.get(book.isbn13) ?? null}
+                ownership={tiers[index].ownership}
+                ebook={tiers[index].ebook}
               />
             ))}
           </div>

--- a/components/search/BookCard.tsx
+++ b/components/search/BookCard.tsx
@@ -1,18 +1,23 @@
-import { Suspense } from "react";
 import Image from "next/image";
 import { PhysicalOwnershipBadge } from "@/components/search/PhysicalOwnershipBadge";
-import { EbookAvailabilityCell } from "@/components/search/EbookAvailabilityCell";
-import { AvailabilitySkeleton } from "@/components/search/AvailabilitySkeleton";
+import { EbookBadge } from "@/components/search/EbookBadge";
 import type { PhysicalOwnership } from "@/lib/services/book-existence";
+import type { EbookExistence } from "@/lib/services/book-existence";
 import type { Book, Library } from "@/types";
 
 interface BookCardProps {
   book: Book;
   libraries: Library[];
   ownership: PhysicalOwnership | null;
+  ebook: EbookExistence | null;
 }
 
-export function BookCard({ book, libraries, ownership }: BookCardProps) {
+export function BookCard({
+  book,
+  libraries,
+  ownership,
+  ebook,
+}: BookCardProps) {
   return (
     <article className="rounded-lg border border-border p-4">
       <div className="flex gap-4">
@@ -77,13 +82,7 @@ export function BookCard({ book, libraries, ownership }: BookCardProps) {
               </td>
               {libraries.map((lib) => (
                 <td key={lib.libCode} className="px-3 py-2">
-                  <Suspense fallback={<AvailabilitySkeleton />}>
-                    <EbookAvailabilityCell
-                      keyword={book.title}
-                      libCode={lib.libCode}
-                      homepage={lib.homepage}
-                    />
-                  </Suspense>
+                  <EbookBadge ebook={ebook} libCode={lib.libCode} />
                 </td>
               ))}
             </tr>

--- a/components/search/EbookAvailabilityCell.tsx
+++ b/components/search/EbookAvailabilityCell.tsx
@@ -1,4 +1,4 @@
-import { scrapeEbookAvailability } from "@/lib/api/ebook-scraper";
+import { scrapeEbookAvailabilityLegacy as scrapeEbookAvailability } from "@/lib/api/ebook-scraper";
 
 interface EbookAvailabilityCellProps {
   keyword: string;

--- a/components/search/EbookBadge.tsx
+++ b/components/search/EbookBadge.tsx
@@ -1,0 +1,38 @@
+import type { EbookExistence } from "@/lib/services/book-existence";
+import { getEbookInfo } from "@/lib/services/book-existence";
+
+interface EbookBadgeProps {
+  ebook: EbookExistence | null;
+  libCode: string;
+}
+
+export function EbookBadge({ ebook, libCode }: EbookBadgeProps) {
+  if (ebook === null) {
+    return <span className="text-sm text-muted-foreground">조회 실패</span>;
+  }
+
+  const info = getEbookInfo(ebook, libCode);
+
+  if (info === null || info.status === "unavailable") {
+    return <span className="text-sm text-muted-foreground">조회 실패</span>;
+  }
+
+  if (info.status === "missing") {
+    return <span className="text-sm text-muted-foreground">없음</span>;
+  }
+
+  if (info.ebookUrl) {
+    return (
+      <a
+        href={info.ebookUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm font-medium text-green-600 underline underline-offset-4 hover:text-green-700"
+      >
+        있음
+      </a>
+    );
+  }
+
+  return <span className="text-sm font-medium text-green-600">있음</span>;
+}

--- a/lib/api/ebook-scraper.ts
+++ b/lib/api/ebook-scraper.ts
@@ -2,27 +2,88 @@ import "server-only";
 import { EBOOK_LIBRARY_CONFIGS } from "@/lib/constants/ebook-library-config";
 import { discoverEbookUrl } from "@/lib/api/ebook-discovery";
 import { buildEbookSearchUrl } from "@/lib/constants/domain-patterns";
+import type { Result } from "@/lib/api/data4library";
 
 const TIMEOUT_MS = 5000;
+const USER_AGENT = "Mozilla/5.0 (compatible; library-checker/1.0)";
 
-export type EbookScrapeResult =
-  | { libCode: string; libName: string; ebookAvailable: "Y" | "N"; ebookUrl?: string }
-  | { libCode: string; error: string };
-
-export type EbookScrapeTarget = {
+/**
+ * 전자책 스크래핑 결과 (data access layer).
+ * fetch/parse만 담당하며 비즈니스 해석은 service layer에서 수행한다.
+ *
+ * - ebookUrl: 전자도서관 검색 URL (있을 경우)
+ * - ebookAvailable: config 기반 판정이 가능한 경우만 "Y"/"N".
+ *   자동 발견 경로에서는 HTML 구조를 모르므로 "Y" (URL 존재 = 있음 처리)
+ */
+export type EbookScrapeData = {
   libCode: string;
-  homepage?: string;
+  libName: string;
+  ebookAvailable: "Y" | "N";
+  ebookUrl: string | null;
 };
+
+async function scrapeWithConfig(
+  keyword: string,
+  libCode: string,
+): Promise<Result<EbookScrapeData>> {
+  const config = EBOOK_LIBRARY_CONFIGS[libCode];
+  if (!config) {
+    return { success: false, error: "config 없음" };
+  }
+
+  try {
+    const url = config.searchUrl(keyword);
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { "User-Agent": USER_AGENT },
+    });
+
+    if (!response.ok) {
+      return { success: false, error: "조회 실패" };
+    }
+
+    const html = await response.text();
+    const isEmpty = config.emptyTexts.some((text) => html.includes(text));
+
+    if (isEmpty) {
+      return {
+        success: true,
+        data: {
+          libCode,
+          libName: config.libName,
+          ebookAvailable: "N",
+          ebookUrl: null,
+        },
+      };
+    }
+
+    const isAvailable = config.availableTexts.some((text) =>
+      html.includes(text),
+    );
+
+    return {
+      success: true,
+      data: {
+        libCode,
+        libName: config.libName,
+        ebookAvailable: isAvailable ? "Y" : "N",
+        ebookUrl: url,
+      },
+    };
+  } catch {
+    return { success: false, error: "조회 실패" };
+  }
+}
 
 async function scrapeWithDiscovery(
   keyword: string,
   libCode: string,
-  homepage: string
-): Promise<EbookScrapeResult> {
+  homepage: string,
+): Promise<Result<EbookScrapeData>> {
   const ebookPortalUrl = await discoverEbookUrl(homepage);
 
   if (!ebookPortalUrl) {
-    return { libCode, error: "전자도서관 미운영" };
+    return { success: false, error: "전자도서관 미운영" };
   }
 
   const searchUrl = buildEbookSearchUrl(ebookPortalUrl, keyword);
@@ -30,92 +91,130 @@ async function scrapeWithDiscovery(
   try {
     const response = await fetch(searchUrl, {
       signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; library-checker/1.0)" },
+      headers: { "User-Agent": USER_AGENT },
     });
 
     if (!response.ok) {
-      return { libCode, error: "조회 실패" };
+      return {
+        success: true,
+        data: {
+          libCode,
+          libName: libCode,
+          ebookAvailable: "Y",
+          ebookUrl: ebookPortalUrl,
+        },
+      };
     }
 
-    // When using auto-discovery we cannot know the page's empty/available text
-    // patterns, so we return the ebook URL for the user to check manually.
     return {
-      libCode,
-      libName: libCode,
-      ebookAvailable: "Y",
-      ebookUrl: searchUrl,
+      success: true,
+      data: {
+        libCode,
+        libName: libCode,
+        ebookAvailable: "Y",
+        ebookUrl: searchUrl,
+      },
     };
   } catch {
-    // Fetch failed but we did find the portal — still return the URL
     return {
-      libCode,
-      libName: libCode,
-      ebookAvailable: "Y",
-      ebookUrl: ebookPortalUrl,
+      success: true,
+      data: {
+        libCode,
+        libName: libCode,
+        ebookAvailable: "Y",
+        ebookUrl: ebookPortalUrl,
+      },
     };
   }
 }
 
+/**
+ * 단일 도서관에 대해 전자책 스크래핑을 수행한다 (Result 패턴).
+ *
+ * - config가 정의된 도서관: HTML 분석으로 정확한 Y/N 판정
+ * - config 없고 homepage 제공: 자동 발견 후 URL 반환 (Y로 처리)
+ * - config 없고 homepage 없음: 실패 (전자도서관 미운영)
+ */
 export async function scrapeEbookAvailability(
   keyword: string,
   libCode: string,
-  homepage?: string
-): Promise<EbookScrapeResult> {
-  const config = EBOOK_LIBRARY_CONFIGS[libCode];
-
-  if (!config) {
-    if (homepage) {
-      return scrapeWithDiscovery(keyword, libCode, homepage);
-    }
-    return { libCode, error: "전자도서관 미운영" };
+  homepage?: string,
+): Promise<Result<EbookScrapeData>> {
+  if (EBOOK_LIBRARY_CONFIGS[libCode]) {
+    return scrapeWithConfig(keyword, libCode);
   }
 
-  try {
-    const url = config.searchUrl(keyword);
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; library-checker/1.0)" },
-    });
-
-    if (!response.ok) {
-      return { libCode, error: "조회 실패" };
-    }
-
-    const html = await response.text();
-    const isEmpty = config.emptyTexts.some((text) => html.includes(text));
-
-    if (isEmpty) {
-      return { libCode, libName: config.libName, ebookAvailable: "N" };
-    }
-
-    const isAvailable = config.availableTexts.some((text) =>
-      html.includes(text)
-    );
-
-    return {
-      libCode,
-      libName: config.libName,
-      ebookAvailable: isAvailable ? "Y" : "N",
-    };
-  } catch {
-    return { libCode, error: "조회 실패" };
+  if (homepage) {
+    return scrapeWithDiscovery(keyword, libCode, homepage);
   }
+
+  return { success: false, error: "전자도서관 미운영" };
 }
 
+// ============================================================================
+// Legacy exports — 아래는 PR4에서 제거 예정. 기존 호출부(EbookAvailabilityCell,
+// app/api/ebook-availability/route.ts) 호환을 위해 유지한다.
+// ============================================================================
+
+export type EbookScrapeResult =
+  | {
+      libCode: string;
+      libName: string;
+      ebookAvailable: "Y" | "N";
+      ebookUrl?: string;
+    }
+  | { libCode: string; error: string };
+
+export type EbookScrapeTarget = {
+  libCode: string;
+  homepage?: string;
+};
+
+function toLegacyResult(
+  libCode: string,
+  result: Result<EbookScrapeData>,
+): EbookScrapeResult {
+  if (!result.success) {
+    return { libCode, error: result.error };
+  }
+  const { data } = result;
+  const legacy: EbookScrapeResult = {
+    libCode: data.libCode,
+    libName: data.libName,
+    ebookAvailable: data.ebookAvailable,
+  };
+  if (data.ebookUrl) {
+    legacy.ebookUrl = data.ebookUrl;
+  }
+  return legacy;
+}
+
+/** @deprecated PR4에서 제거 예정. Result 패턴인 scrapeEbookAvailability 사용. */
+export async function scrapeEbookAvailabilityLegacy(
+  keyword: string,
+  libCode: string,
+  homepage?: string,
+): Promise<EbookScrapeResult> {
+  const result = await scrapeEbookAvailability(keyword, libCode, homepage);
+  return toLegacyResult(libCode, result);
+}
+
+/** @deprecated PR4에서 제거 예정. */
 export async function scrapeEbookAvailabilityBatch(
   keyword: string,
-  targets: ReadonlyArray<EbookScrapeTarget>
+  targets: ReadonlyArray<EbookScrapeTarget>,
 ): Promise<EbookScrapeResult[]> {
   const results = await Promise.allSettled(
     targets.map((target) =>
-      scrapeEbookAvailability(keyword, target.libCode, target.homepage)
-    )
+      scrapeEbookAvailability(keyword, target.libCode, target.homepage),
+    ),
   );
 
-  return results.map((result, index) => {
-    if (result.status === "fulfilled") {
-      return result.value;
+  return results.map((settled, index) => {
+    const libCode = targets[index].libCode;
+    if (settled.status === "fulfilled") {
+      return toLegacyResult(libCode, settled.value);
     }
-    return { libCode: targets[index].libCode, error: "조회 실패" };
+    return { libCode, error: "조회 실패" };
   });
 }

--- a/lib/services/book-existence.ts
+++ b/lib/services/book-existence.ts
@@ -1,8 +1,15 @@
 import "server-only";
+import { unstable_cache } from "next/cache";
 import {
   fetchLibrariesByBook,
   type Result,
 } from "@/lib/api/data4library";
+import { scrapeEbookAvailability } from "@/lib/api/ebook-scraper";
+import type { Library } from "@/types";
+
+// ============================================================================
+// Tier 1: Physical ownership
+// ============================================================================
 
 export type PhysicalOwnership = {
   owningLibCodes: Set<string>;
@@ -28,4 +35,118 @@ export function isOwnedBy(
   libCode: string,
 ): boolean {
   return ownership.owningLibCodes.has(libCode);
+}
+
+// ============================================================================
+// Tier 2: Ebook existence (24h cache)
+// ============================================================================
+
+/**
+ * libCode별 전자책 존재 상태.
+ * - "exists": 전자책이 있음 (URL 제공 가능)
+ * - "missing": 도서관에서 해당 도서의 전자책을 제공하지 않음
+ * - "unavailable": 전자도서관 미운영 또는 조회 실패
+ */
+export type EbookStatus = "exists" | "missing" | "unavailable";
+
+export type EbookInfo = {
+  status: EbookStatus;
+  ebookUrl: string | null;
+};
+
+export type EbookExistence = {
+  /** libCode → EbookInfo. O(1) 조회 */
+  infoByLibCode: Map<string, EbookInfo>;
+};
+
+/**
+ * 캐시 메커니즘 선택: `unstable_cache`
+ *
+ * 이 서비스는 단일 fetch가 아니라 여러 단계(자동 발견 → 검색 URL fetch →
+ * HTML 파싱)의 조합 결과를 캐싱해야 한다. `fetch`의 `next.revalidate`는
+ * 개별 HTTP 요청 단위로만 동작하므로, 조합된 결과 캐싱에는 부적합하다.
+ * `unstable_cache`는 임의의 async 함수 결과를 (bookTitle, libCode) 키로
+ * 캐시할 수 있어 훨씬 더 적합하다. Next 16에서도 안정적으로 사용 가능.
+ */
+const ONE_DAY_SECONDS = 60 * 60 * 24;
+
+async function scrapeEbookForLibrary(
+  bookTitle: string,
+  libCode: string,
+  homepage: string,
+): Promise<EbookInfo> {
+  const result = await scrapeEbookAvailability(bookTitle, libCode, homepage);
+
+  if (!result.success) {
+    return { status: "unavailable", ebookUrl: null };
+  }
+
+  const { data } = result;
+  if (data.ebookAvailable === "N") {
+    return { status: "missing", ebookUrl: null };
+  }
+
+  return { status: "exists", ebookUrl: data.ebookUrl };
+}
+
+/**
+ * 24시간 캐시가 적용된 도서관 단위 전자책 조회.
+ *
+ * 캐시 키: ["ebook-existence", bookTitle, libCode]
+ * 태그: "ebook-existence", `ebook-existence:{libCode}` — 필요 시 부분 무효화.
+ */
+const getCachedEbookForLibrary = unstable_cache(
+  scrapeEbookForLibrary,
+  ["ebook-existence"],
+  {
+    revalidate: ONE_DAY_SECONDS,
+    tags: ["ebook-existence"],
+  },
+);
+
+/**
+ * 주어진 책 제목에 대해 선택된 도서관 전체의 전자책 존재 여부를 조회한다.
+ * 병렬 스크래핑 + 24h 캐시.
+ */
+export async function getEbookExistence(
+  bookTitle: string,
+  libraries: ReadonlyArray<Library>,
+): Promise<Result<EbookExistence>> {
+  if (!bookTitle.trim() || libraries.length === 0) {
+    return {
+      success: true,
+      data: { infoByLibCode: new Map() },
+    };
+  }
+
+  const settled = await Promise.allSettled(
+    libraries.map((lib) =>
+      getCachedEbookForLibrary(bookTitle, lib.libCode, lib.homepage),
+    ),
+  );
+
+  const infoByLibCode = new Map<string, EbookInfo>();
+  libraries.forEach((lib, index) => {
+    const result = settled[index];
+    if (result.status === "fulfilled") {
+      infoByLibCode.set(lib.libCode, result.value);
+    } else {
+      infoByLibCode.set(lib.libCode, {
+        status: "unavailable",
+        ebookUrl: null,
+      });
+    }
+  });
+
+  return {
+    success: true,
+    data: { infoByLibCode },
+  };
+}
+
+export function getEbookInfo(
+  existence: EbookExistence,
+  libCode: string,
+): EbookInfo | null {
+  return existence.infoByLibCode.get(libCode) ?? null;
 }


### PR DESCRIPTION
## Summary

이슈 #12의 PR2. `/search` 결과에 Tier 2(전자책 존재 여부 + 24시간 캐시)를 추가한다. PR1에서 추가된 Tier 1(실물 소장)과 책별로 병렬 조회된다.

## 변경 사항

- `lib/api/ebook-scraper.ts`
  - Result 패턴(`{ success, data } | { success, error }`)으로 전면 리팩터링
  - fetch/parse만 담당 — 비즈니스 해석은 service layer로 이동
  - `AbortSignal.timeout(5000)` 적용 확인
  - legacy 호환용 `scrapeEbookAvailabilityLegacy` / `scrapeEbookAvailabilityBatch` 제공 (PR4에서 제거 예정)
- `lib/services/book-existence.ts`
  - `getEbookExistence(bookTitle, libraries)` 추가
  - `EbookExistence = { infoByLibCode: Map<libCode, EbookInfo> }` — 배지에서 O(1) 조회
  - `EbookStatus = "exists" | "missing" | "unavailable"`
  - **24시간 캐시**: `unstable_cache` 사용. 선택 이유는 `scrapeEbookForLibrary`가 (자동 발견 → 검색 fetch → HTML 파싱) 다단계 조합이라 단일 `fetch next.revalidate`로는 조합 결과 캐싱이 불가능함. `unstable_cache`는 async 함수 결과를 `(bookTitle, libCode)` 키로 캐시 가능. 관련 주석 포함.
- `components/search/EbookBadge.tsx` (신규)
  - Server Component. props: `{ ebook: EbookExistence | null; libCode: string }`
  - "있음" / "없음" / "조회 실패" 렌더링. URL 있을 경우 링크
- `app/search/page.tsx`
  - 책별로 Tier 1 + Tier 2 `Promise.allSettled` 병렬 fetch (`fetchTiersForBook`)
  - 책 간에도 `Promise.all` 병렬화
- `components/search/BookCard.tsx`
  - `ebook: EbookExistence | null` prop 추가
  - 기존 `<EbookAvailabilityCell>` + Suspense → `<EbookBadge>` 교체
- 기존 `EbookAvailabilityCell.tsx` / `/api/ebook-availability` route는 **유지** (PR4에서 정리)

## 설계 결정

- **`unstable_cache` 채택 이유**: 단순 fetch revalidate는 단계별 캐시만 가능하므로, `(bookTitle, libCode) → EbookInfo` 조합 결과 캐싱에 부적합. `unstable_cache` + `revalidate: 86400` 조합이 요구사항(24h)과 정확히 맞아떨어짐.
- **캐시 태그**: `["ebook-existence"]` — 향후 부분 무효화 hook 가능.
- **`EbookExistence`를 Map 기반으로** 설계해 배지 렌더링 시 `.get(libCode)` O(1) 조회.

## Self-review 체크리스트

- [x] 새 외부 HTTP 호출에 `AbortSignal.timeout(5000)` 적용
- [x] `lib/api/` 함수가 Result 패턴 반환
- [x] `Promise.allSettled`로 병렬 fan-out (책별, 도서관별 모두)
- [x] Server Component 기본, `"use client"` 없음
- [x] Props는 `interface`로 정의
- [x] `@/` 절대 import 사용
- [x] 모든 파일 400줄 이하 (최대: `ebook-scraper.ts` ~200줄)
- [x] `npx tsc --noEmit` 통과

## Test plan

- [ ] `/search?q=...&libs=...` 진입 시 결과 페이지 렌더
- [ ] 각 도서 행의 "전자책" 셀에 "있음" / "없음" / "조회 실패" 중 하나 표시
- [ ] "있음"인 경우 링크 클릭 시 도서관 전자도서관 검색 결과로 이동
- [ ] 같은 `(제목, 도서관)` 조합 재조회 시 24h 내에는 네트워크 재요청 없음 (캐시 히트)
- [ ] Tier 2 실패해도 Tier 1 배지가 정상 렌더
- [ ] 타임아웃/에러 발생 시 "조회 실패" 표시되고 페이지 크래시 없음

Closes: 이슈 #12의 PR2 단계 (PR3/PR4에서 후속 작업)