### PR TITLE
feat: Tier 3 대출 가능 on-demand 확인 (#12 PR3)

### DIFF
--- a/app/api/book-availability/route.ts
+++ b/app/api/book-availability/route.ts
@@ -1,60 +1,77 @@
 import { NextRequest, NextResponse } from "next/server";
-import { fetchBookAvailability } from "@/lib/api/data4library";
-import type { PhysicalAvailability } from "@/types";
+import {
+  checkLoanStatus,
+  type CheckLoanStatusData,
+} from "@/lib/services/book-availability";
 
-type BookAvailabilityResponse = {
+type ApiResponse<T> = {
   success: boolean;
-  data?: PhysicalAvailability[];
+  data?: T;
   error?: string;
 };
 
-export async function GET(
-  request: NextRequest
-): Promise<NextResponse<BookAvailabilityResponse>> {
-  const { searchParams } = request.nextUrl;
-  const isbn13 = searchParams.get("isbn13")?.trim() ?? "";
-  const libCodesParam = searchParams.get("libCodes")?.trim() ?? "";
+type PostBody = {
+  isbn13?: unknown;
+  libCodes?: unknown;
+};
 
-  if (!isbn13) {
-    return NextResponse.json(
-      { success: false, error: "isbn13 is required" },
-      { status: 400 }
-    );
+function parseBody(raw: unknown):
+  | { success: true; isbn13: string; libCodes: string[] }
+  | { success: false; error: string } {
+  if (!raw || typeof raw !== "object") {
+    return { success: false, error: "Request body must be a JSON object" };
   }
 
-  if (!libCodesParam) {
-    return NextResponse.json(
-      { success: false, error: "libCodes is required" },
-      { status: 400 }
-    );
+  const body = raw as PostBody;
+
+  if (typeof body.isbn13 !== "string" || body.isbn13.trim().length === 0) {
+    return { success: false, error: "isbn13 is required" };
   }
 
-  const libCodes = libCodesParam
-    .split(",")
+  if (!Array.isArray(body.libCodes)) {
+    return { success: false, error: "libCodes must be an array" };
+  }
+
+  const libCodes = body.libCodes
+    .filter((code): code is string => typeof code === "string")
     .map((code) => code.trim())
-    .filter(Boolean);
+    .filter((code) => code.length > 0);
 
+  return { success: true, isbn13: body.isbn13.trim(), libCodes };
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<ApiResponse<CheckLoanStatusData>>> {
+  let rawBody: unknown;
   try {
-    const results = await Promise.allSettled(
-      libCodes.map((libCode) => fetchBookAvailability(isbn13, libCode))
-    );
-
-    const data: PhysicalAvailability[] = results
-      .filter(
-        (r): r is PromiseFulfilledResult<PhysicalAvailability> =>
-          r.status === "fulfilled" && r.value !== null
-      )
-      .map((r) => r.value);
-
-    return NextResponse.json({ success: true, data });
-  } catch (error: unknown) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "Failed to fetch book availability";
+    rawBody = await request.json();
+  } catch {
     return NextResponse.json(
-      { success: false, error: message },
-      { status: 500 }
+      { success: false, error: "Invalid JSON body" },
+      { status: 400 },
     );
   }
+
+  const parsed = parseBody(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error },
+      { status: 400 },
+    );
+  }
+
+  const result = await checkLoanStatus({
+    isbn13: parsed.isbn13,
+    libCodes: parsed.libCodes,
+  });
+
+  if (!result.success) {
+    return NextResponse.json(
+      { success: false, error: result.error },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true, data: result.data });
 }

--- a/components/search/AvailabilityCheckButton.tsx
+++ b/components/search/AvailabilityCheckButton.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { Library } from "@/types";
+import type { LoanStatus } from "@/lib/services/book-availability";
+
+interface AvailabilityCheckButtonProps {
+  isbn13: string;
+  owningLibCodes: string[];
+  libraries: Library[];
+}
+
+type FetchState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "success"; statusByLibCode: Record<string, LoanStatus> };
+
+type ApiResponse = {
+  success: boolean;
+  data?: { statusByLibCode: Record<string, LoanStatus> };
+  error?: string;
+};
+
+const STATUS_LABEL: Record<LoanStatus, string> = {
+  available: "대출 가능",
+  "on-loan": "대출 중",
+  "not-owned": "미소장",
+  error: "조회 실패",
+};
+
+const STATUS_CLASS: Record<LoanStatus, string> = {
+  available: "text-green-600 font-medium",
+  "on-loan": "text-amber-600",
+  "not-owned": "text-muted-foreground",
+  error: "text-muted-foreground",
+};
+
+export function AvailabilityCheckButton({
+  isbn13,
+  owningLibCodes,
+  libraries,
+}: AvailabilityCheckButtonProps) {
+  const [state, setState] = useState<FetchState>({ kind: "idle" });
+
+  const hasOwningLibs = owningLibCodes.length > 0;
+
+  if (!hasOwningLibs) {
+    return (
+      <p className="mt-3 text-xs text-muted-foreground">소장 도서관 없음</p>
+    );
+  }
+
+  async function handleCheck() {
+    setState({ kind: "loading" });
+    try {
+      const response = await fetch("/api/book-availability", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isbn13, libCodes: owningLibCodes }),
+      });
+
+      const json = (await response.json()) as ApiResponse;
+
+      if (!response.ok || !json.success || !json.data) {
+        setState({
+          kind: "error",
+          message: json.error ?? "대출 가능 여부 조회에 실패했습니다.",
+        });
+        return;
+      }
+
+      setState({ kind: "success", statusByLibCode: json.data.statusByLibCode });
+    } catch {
+      setState({
+        kind: "error",
+        message: "네트워크 오류로 조회에 실패했습니다.",
+      });
+    }
+  }
+
+  const owningLibraries = libraries.filter((lib) =>
+    owningLibCodes.includes(lib.libCode),
+  );
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleCheck}
+        disabled={state.kind === "loading"}
+        className="self-start"
+      >
+        {state.kind === "loading" ? "조회 중..." : "대출 가능 확인"}
+      </Button>
+
+      {state.kind === "error" && (
+        <p className="text-xs text-red-600" role="alert">
+          {state.message}
+        </p>
+      )}
+
+      {state.kind === "success" && (
+        <ul className="flex flex-col gap-1 text-sm">
+          {owningLibraries.map((lib) => {
+            const status = state.statusByLibCode[lib.libCode] ?? "error";
+            return (
+              <li key={lib.libCode} className="flex justify-between gap-3">
+                <span className="text-muted-foreground">{lib.libName}</span>
+                <span className={STATUS_CLASS[status]}>
+                  {STATUS_LABEL[status]}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/search/BookCard.tsx
+++ b/components/search/BookCard.tsx
@@ -1,8 +1,11 @@
 import Image from "next/image";
 import { PhysicalOwnershipBadge } from "@/components/search/PhysicalOwnershipBadge";
 import { EbookBadge } from "@/components/search/EbookBadge";
-import type { PhysicalOwnership } from "@/lib/services/book-existence";
-import type { EbookExistence } from "@/lib/services/book-existence";
+import { AvailabilityCheckButton } from "@/components/search/AvailabilityCheckButton";
+import type {
+  PhysicalOwnership,
+  EbookExistence,
+} from "@/lib/services/book-existence";
 import type { Book, Library } from "@/types";
 
 interface BookCardProps {
@@ -89,6 +92,14 @@ export function BookCard({
           </tbody>
         </table>
       </div>
+
+      <AvailabilityCheckButton
+        isbn13={book.isbn13}
+        owningLibCodes={
+          ownership ? Array.from(ownership.owningLibCodes) : []
+        }
+        libraries={libraries}
+      />
     </article>
   );
 }

--- a/lib/api/data4library.ts
+++ b/lib/api/data4library.ts
@@ -231,3 +231,40 @@ export async function fetchBookAvailability(
     loanAvailable: result.loanAvailable,
   };
 }
+
+export async function fetchBookLoanStatus(
+  isbn13: string,
+  libCode: string,
+): Promise<Result<{ hasBook: "Y" | "N"; loanAvailable: "Y" | "N" }>> {
+  try {
+    const url = buildUrl("/bookExist", { isbn13, libCode });
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `bookExist API error: ${response.status}`,
+      };
+    }
+
+    const json = (await response.json()) as {
+      response?: { result?: Data4LibraryAvailabilityResult };
+    };
+
+    const result = json.response?.result;
+    if (!result) {
+      return { success: false, error: "bookExist: empty result" };
+    }
+
+    return {
+      success: true,
+      data: { hasBook: result.hasBook, loanAvailable: result.loanAvailable },
+    };
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : "bookExist request failed";
+    return { success: false, error: message };
+  }
+}

--- a/lib/services/book-availability.ts
+++ b/lib/services/book-availability.ts
@@ -1,0 +1,59 @@
+import "server-only";
+import {
+  fetchBookLoanStatus,
+  type Result,
+} from "@/lib/api/data4library";
+
+export type LoanStatus = "available" | "on-loan" | "not-owned" | "error";
+
+export type CheckLoanStatusInput = {
+  isbn13: string;
+  libCodes: string[];
+};
+
+export type CheckLoanStatusData = {
+  statusByLibCode: Record<string, LoanStatus>;
+};
+
+function toLoanStatus(hasBook: "Y" | "N", loanAvailable: "Y" | "N"): LoanStatus {
+  if (hasBook === "N") return "not-owned";
+  return loanAvailable === "Y" ? "available" : "on-loan";
+}
+
+export async function checkLoanStatus(
+  input: CheckLoanStatusInput,
+): Promise<Result<CheckLoanStatusData>> {
+  const { isbn13, libCodes } = input;
+
+  if (!isbn13) {
+    return { success: false, error: "isbn13 is required" };
+  }
+
+  if (libCodes.length === 0) {
+    return { success: true, data: { statusByLibCode: {} } };
+  }
+
+  const settled = await Promise.allSettled(
+    libCodes.map((libCode) => fetchBookLoanStatus(isbn13, libCode)),
+  );
+
+  const statusByLibCode: Record<string, LoanStatus> = {};
+  libCodes.forEach((libCode, index) => {
+    const result = settled[index];
+    if (result.status !== "fulfilled") {
+      statusByLibCode[libCode] = "error";
+      return;
+    }
+    const value = result.value;
+    if (!value.success) {
+      statusByLibCode[libCode] = "error";
+      return;
+    }
+    statusByLibCode[libCode] = toLoanStatus(
+      value.data.hasBook,
+      value.data.loanAvailable,
+    );
+  });
+
+  return { success: true, data: { statusByLibCode } };
+}


### PR DESCRIPTION
## Summary
이슈 #12의 Tier 3 구현. 사용자가 버튼을 눌렀을 때만 `bookExist` API를 호출해 실시간 대출 가능 여부를 확인한다. Tier 1(libSrchByBook)이 소장을 확인한 도서관 코드에 대해서만 요청한다.

Closes part of #12 (Tier 3).

## 변경 사항
- `lib/api/data4library.ts`: `fetchBookLoanStatus` 추가 — Result 패턴 + `AbortSignal.timeout(5000)` 적용한 `bookExist` 래퍼
- `lib/services/book-availability.ts` (신규): `checkLoanStatus({ isbn13, libCodes })` — `Promise.allSettled`로 병렬 조회 후 `LoanStatus = "available" | "on-loan" | "not-owned" | "error"`로 매핑
- `app/api/book-availability/route.ts`: POST 핸들러로 재작성. 수동 JSON 바디 검증(zod 미설치), 표준 응답 envelope `{ success, data?, error? }` 적용
- `components/search/AvailabilityCheckButton.tsx` (신규, `"use client"`): 버튼 클릭 시 `/api/book-availability`에 POST. idle/loading/error/success 상태 관리. `owningLibCodes.length === 0`이면 "소장 도서관 없음" 표시
- `components/search/BookCard.tsx`: 기존 테이블 아래에 `AvailabilityCheckButton` 추가. `ownership.owningLibCodes`에서 배열 추출해 전달

## Self-review checklist
- [x] 외부 API 호출에 `AbortSignal.timeout(5000)` 적용 (`fetchBookLoanStatus`)
- [x] Result 패턴 준수 (`lib/api/`, `lib/services/`)
- [x] `Promise.allSettled`로 fan-out
- [x] API 라우트 envelope 표준 (`{ success, data?, error? }`)
- [x] `"use client"`는 버튼 컴포넌트에만
- [x] Props를 `interface`로 정의
- [x] `@/` 절대 경로 import
- [x] 모든 파일 400줄 이하 (최대 123줄)
- [x] `npx tsc --noEmit` 통과

## Test plan
- [ ] `/search?q=...&libs=...` 진입 후 책 카드에 "대출 가능 확인" 버튼 노출 확인
- [ ] Tier 1이 미소장으로 확인한 책 → 버튼 대신 "소장 도서관 없음" 표시 확인
- [ ] 버튼 클릭 → 로딩 상태 → 각 소장 도서관별 "대출 가능/대출 중/미소장/조회 실패" 목록 렌더링 확인
- [ ] `data4library` API 오류/타임아웃(5s 초과) 상황에서 상태 매핑이 `error`로 표시되는지 확인
- [ ] POST `/api/book-availability` 잘못된 바디(빈 isbn13, libCodes 누락 등) → 400 응답 확인
- [ ] 네트워크 실패(오프라인) → 사용자 친화적 에러 메시지 노출 확인